### PR TITLE
Converting meta from struct

### DIFF
--- a/examples/sssp/sssp.cu
+++ b/examples/sssp/sssp.cu
@@ -35,14 +35,14 @@ void test_sssp(int num_arguments, char** argument_array) {
   auto [G, meta] = graph::build::from_csr_t<memory_space_t::device>(&csr);
   
   using graph_t = decltype(G)::value_type;
-  using meta_t  = decltype(meta)::value_type;
+  using meta_t  = decltype(meta);
   
   // --
   // Params and memory allocation
   
   vertex_t single_source = 0;
   
-  vertex_t n_vertices = meta[0].get_number_of_vertices();
+  vertex_t n_vertices = meta.get_number_of_vertices();
   thrust::device_vector<weight_t> distances(n_vertices);
   thrust::device_vector<vertex_t> predecessors(n_vertices);
   

--- a/gunrock/applications/runner.hxx
+++ b/gunrock/applications/runner.hxx
@@ -38,7 +38,7 @@ float run(graph_vector_t& G,
   std::shared_ptr<problem_t> problem(
     std::make_shared<problem_t>(
       G.data().get(),    // input graph (GPU)
-      meta.data(),       // metadata    (CPU)
+      meta,              // metadata    (CPU)
       multi_context,     // input context
       param,             // input parameters
       result));          // output results

--- a/gunrock/applications/sssp/sssp_implementation.hxx
+++ b/gunrock/applications/sssp/sssp_implementation.hxx
@@ -63,7 +63,7 @@ struct sssp_problem_t : problem_t<d_graph_t, meta_t> {
   thrust::device_vector<vertex_t> visited;
 
   sssp_problem_t(d_graph_t* d_G,
-                 meta_t* meta,
+                 meta_t& meta,
                  std::shared_ptr<cuda::multi_context_t> context,
                  param_t& param,
                  result_t& result) :
@@ -71,17 +71,14 @@ struct sssp_problem_t : problem_t<d_graph_t, meta_t> {
       single_source(param.single_source),
       distances(result.distances),
       predecessors(result.predecessors),
-      visited(meta[0].get_number_of_vertices(), -1)
+      visited(meta.get_number_of_vertices(), -1)
    {
-
-
-    auto n_vertices = meta[0].get_number_of_vertices();
 
     auto d_distances = thrust::device_pointer_cast(distances);
     thrust::fill(
       thrust::device,
       d_distances + 0,
-      d_distances + n_vertices,
+      d_distances + meta.get_number_of_vertices(),
       std::numeric_limits<weight_t>::max()
     );
     thrust::fill(thrust::device, d_distances + single_source, d_distances + single_source + 1, 0);

--- a/gunrock/framework/problem.hxx
+++ b/gunrock/framework/problem.hxx
@@ -42,9 +42,9 @@ struct problem_t {
 
   problem_t() : graph_slice(nullptr) {}
   problem_t(graph_type* G,
-            host_graph_type* g,
+            host_graph_type& meta,
             std::shared_ptr<cuda::multi_context_t> _context)
-      : graph_slice(G), host_graph_slice(g), context(_context) {}
+      : graph_slice(G), host_graph_slice(&meta), context(_context) {}
 
   // Disable copy ctor and assignment operator.
   // We do not want to let user copy only a slice.

--- a/gunrock/graph/build.hxx
+++ b/gunrock/graph/build.hxx
@@ -119,19 +119,9 @@ auto from_csr_t(typename vertex_vector_t::value_type const& r,
   }
   
   // Meta
-  constexpr memory_space_t h_space = memory_space_t::host;
-
-  using meta_type = graph::graph_t<
-      h_space, vertex_type, edge_type, weight_type,
-      graph::graph_csr_t<h_space, vertex_type, edge_type, weight_type>>;
-
-  typename vector<meta_type, h_space>::type P(1);
-  meta_type M;
-
-  M.set(r, c, nnz, nullptr, nullptr, nullptr);
-  host::csr_t<meta_type>(M, memory::raw_pointer_cast(P.data()));
+  graph_meta_t<vertex_type, edge_type, weight_type> meta(r, nnz);
   
-  return std::make_pair(O, P);
+  return std::make_pair(O, meta);
 }
 
 template <memory_space_t space, typename csr_t>

--- a/gunrock/graph/graph.hxx
+++ b/gunrock/graph/graph.hxx
@@ -26,6 +26,29 @@ using namespace format;
 using namespace detail;
 using namespace memory;
 
+template <typename vertex_t, typename edge_t, typename weight_t>
+struct graph_meta_t {
+  using vertex_type = vertex_t;
+  using edge_type   = edge_t;
+  using weight_type = weight_t;
+  
+  vertex_t n_vertices;
+  edge_t n_edges;
+  
+  vertex_t get_number_of_vertices() {
+    return n_vertices;
+  }
+
+  vertex_t get_number_of_edges() {
+    return n_edges;
+  }
+  
+  graph_meta_t(
+    vertex_t n_vertices_,
+    edge_t n_edges_
+  ) : n_vertices(n_vertices_), n_edges(n_edges_) {}
+};
+
 /**
  * @brief Variadic inheritence based graph class, inherit only what you need
  * from the formats implemented. See detail/base.hxx for the graph_base_t


### PR DESCRIPTION
Instead of using a full graph, use a simple struct for the metadata.

I thought this would be a good idea, but after implementing it, I don't think it is (at least not the way it's implemented).  We probably want the interface to the `meta` object on CPU to be the same as the interface to the `G` object on GPU.  (I think) that means we have to have two copies of the interface -- which is bad.  

I'd vote leaving `meta` as a full graph w/ `nullptr` to the offsets / indices / etc.